### PR TITLE
Add index of polling stations in Beirut 2 district

### DIFF
--- a/containers/LocalForm.js
+++ b/containers/LocalForm.js
@@ -5,11 +5,94 @@ import locationsData from '../data/polling_station_locations.json';
 import labels from '../i18n.json';
 import linkState from 'linkstate';
 import beirut2 from '../data/beirut2.json';
-console.log(beirut2);
+import sects from '../data/sects.json';
+import villages from '../data/villages.json';
+
+var selectSects = normalizeSects(sects);
+var selectVillages = normalizeVillages(villages);
+
+function normalizeSects(sects) {
+    var selectSects = {};
+    var i = 0;
+    for (var key in sects) {
+        if (sects.hasOwnProperty(key)) {
+            selectSects[sects[key].name_ar] = i;
+            i++;
+        }
+    }
+
+    return selectSects;
+}
+
+function normalizeVillages(villages) {
+    var selectVillages = {};
+    var i = 0;
+    for (var key in villages) {
+        if (villages.hasOwnProperty(key)) {
+            selectVillages[villages[key].name_ar] = i;
+            i++;
+        }
+    }
+
+    return selectVillages;
+}
+
+function sectKeyFromNameAr(nameAr) {
+    return selectSects[nameAr];
+}
+
+function villageKeyFromNameAr(nameAr) {
+    return selectVillages[nameAr];
+}
+
+/**
+ * Processes the polling station data into an index
+ * @param {Object[]} json
+ * @return An index of the polling stations grouped by sect,gender
+ */
+function process(json) {
+    var index = {};
+    json.forEach((item) => {
+        var sect = sectKeyFromNameAr(item.sect);
+        if (!index[sect]) {
+            index[sect] = {};
+        }
+
+        var village = villageKeyFromNameAr(item.subdistrict);
+        if (!index[sect][village]) {
+            index[sect][village] = {};
+        }
+
+        if (!index[sect][village][item.gender]) {
+            index[sect][village][item.gender] = [];
+        }
+
+        index[sect][village][item.gender].push(item);
+    });
+
+    return index;
+}
+
+/**
+ * Checks if the entered values exist in the index
+ * @param {Object} index
+ * @param {Object} entry
+ * @returns {Object[]} list of matching polling stations
+ */
+function checkInIndex(index, entry) {
+    let { sect, village, gender, val } = entry;
+    // console.log(sect + " " + village + " " + gender + " " + val);
+    var fromIndex = index[sect][village][gender];
+    return fromIndex.filter((row) => {
+        return Number(row.from) <= Number(val) && Number(val) <= Number(row.to);
+    });
+}
 
 export default class LocalForm extends Component {
   constructor(props) {
     super(props);
+    this.data = process(beirut2);
+
     this.state = {
       center: null,
       error: '',


### PR DESCRIPTION
This addresses issue #2.

The sect and village names are normalized from Arabic in the original
data file into numerical indices that are used in the <select> elements
on the page.